### PR TITLE
Use roman-numerals-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,9 +330,9 @@ dependencies = [
  "lazy_static",
  "log",
  "mime_guess",
- "numerals",
  "punkt",
  "rayon",
+ "roman-numerals-rs",
  "rust-i18n",
  "simplelog",
  "syntect",
@@ -848,12 +848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "numerals"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25be21376a772d15f97ae789845340a9651d3c4246ff5ebb6a2b35f9c37bd31"
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,6 +1188,12 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "rust-freqdist"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "text-processing"]
 license = "LGPL-2.1+"
 publish = true
 autobins = false
-rust-version = "1.58" 
+rust-version = "1.79"
 
 exclude = [
     "docs/*",
@@ -54,7 +54,7 @@ base64 = "0.21"
 rayon = "1.6"
 crowbook-text-processing = "^1.1.1"
 lazy_static = "1"
-numerals = "0.1"
+roman-numerals-rs = "3.1.0"
 epub-builder = "^0.7.1"
 log = "0.4"
 punkt = { version = "1.0", optional = true }

--- a/src/lib/book.rs
+++ b/src/lib/book.rs
@@ -45,7 +45,7 @@ use std::io::{Read, Write};
 use std::iter::IntoIterator;
 use std::path::{Path, PathBuf};
 
-use numerals::roman::Roman;
+use roman_numerals_rs::RomanNumeral;
 use rayon::prelude::*;
 use yaml_rust::{Yaml, YamlLoader};
 use rust_i18n::t;
@@ -1169,7 +1169,7 @@ impl<'a> Book<'a> {
                     ),
                 ));
             }
-            format!("{:X}", Roman::from(n as i16))
+            format!("{:X}", RomanNumeral::try_from(n).unwrap())
         } else {
             format!("{n}")
         };

--- a/src/lib/html.rs
+++ b/src/lib/html.rs
@@ -37,7 +37,7 @@ use std::collections::BTreeMap;
 use crowbook_text_processing::escape;
 use epub_builder::Toc;
 use epub_builder::TocElement;
-use numerals::roman::Roman;
+use roman_numerals_rs::RomanNumeral;
 use rust_i18n::t;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -353,7 +353,8 @@ impl<'a> HtmlRenderer<'a> {
             {
                 write!(output, "{}.", self.current_chapter[i]).unwrap(); //todo
             } else if self.current_chapter[i] >= 1 {
-                write!(output, "{:X}.", Roman::from(self.current_chapter[i] as i16)).unwrap();
+                let roman = RomanNumeral::try_from(self.current_chapter[i]).unwrap();
+                write!(output, "{:X}.", roman).unwrap();
             } else {
                 error!(
                     "{}",


### PR DESCRIPTION
The [``numerals``](https://crates.io/crates/numerals) crate was last updated five years ago, this PR adopts a no-std / 0BSD crate that is also faster. The crate has a higher MSRV, though, so you may want to defer/reject this PR.

A